### PR TITLE
Requires stripe node library and does set-up

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,0 +1,28 @@
+const keyPublishable = process.env.PUBLISHABLE_KEY
+const keySecret = process.env.SECRET_KEY
+
+const app = require("express")()
+const stripe = require("stripe")(keySecret)
+
+app.get('/', (req, res) =>
+  res.render('index.pug', {keyPublishable}))
+
+app.post('/charge', (req, res) => {
+  let amount = 500
+
+  stripe.customers.create({
+     email: req.body.stripeEmail,
+    source: req.body.stripeToken
+  })
+  .then(customer =>
+    stripe.charges.create({
+      amount,
+      description: 'Sample Charge',
+         currency: 'usd',
+         customer: customer.id
+    }))
+  .then(charge => res.render('charge.pug'))
+})
+
+// Do we need to change the port the strip app is listening on?
+app.listen(4567)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "mongoose-unique-validator": "^1.0.5",
     "morgan": "^1.8.1",
     "multer": "^1.3.0",
-    "serve-favicon": "^2.4.2"
+    "serve-favicon": "^2.4.2",
+    "stripe": "^4.19.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
I npm-installed stripe, following documentation at
`https://stripe.com/docs/checkout/express`.  I saved the
publishable key and the secret key to .env. I set up two routes
for stripe, per the documentation. The index route renders the
Checkout form and displays it to the user.  The charge route
retrieves the email address and card token from the POST request
body.  It uses those parameters to create a Stripe customer.
Next, it invokes the `stripe.charges.create` method, providing
the Customer object as an option. The Stripe Node.js client library
performs those operations asynchronously, which means that you need
to use either callbacks or promises to handle the results and ensure
that the functions are invoked in the correct order.